### PR TITLE
feat(ac): support power consumption stats

### DIFF
--- a/custom_components/midea_ac_lan/midea/devices/ac/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/ac/device.py
@@ -95,7 +95,7 @@ class MideaACDevice(MiedaDevice):
             DeviceAttributes.indirect_wind: False,
             DeviceAttributes.indoor_humidity: 0.0,
             DeviceAttributes.breezeless: False,
-            DeviceAttributes.total_energy_consumption: 0.0,
+            DeviceAttributes.total_energy_consumption: None,
             DeviceAttributes.current_energy_consumption: 0.0,
             DeviceAttributes.realtime_power: 0.0
 

--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -127,12 +127,14 @@ MIDEA_DEVICES = {
             ACAttributes.total_energy_consumption: {
                 "type": "sensor",
                 "name": "Total Energy Consumption",
+                "state_class": "total_increasing",
                 "device_class": DEVICE_CLASS_ENERGY,
                 "unit": ENERGY_KILO_WATT_HOUR
             },
             ACAttributes.current_energy_consumption: {
                 "type": "sensor",
                 "name": "Current Energy Consumption",
+                "state_class": "measurement",
                 "device_class": DEVICE_CLASS_ENERGY,
                 "unit": ENERGY_KILO_WATT_HOUR
             },


### PR DESCRIPTION
This converts total_energy_consumption and current_energy_consumption in long term statistics.

That way, we're able to use it in the Energy Dashboard.