### PR TITLE
Add more attributes for DA devices

### DIFF
--- a/custom_components/midea_ac_lan/midea/devices/da/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/da/device.py
@@ -15,9 +15,21 @@ class DeviceAttributes(StrEnum):
     power = "power"
     start = "start"
     washing_data = "washing_data"
+    program = "program"
     progress = "progress"
     time_remaining = "time_remaining"
-
+    wash_time = "wash_time"
+    soak_time = "soak_time"
+    dehydration_time = "dehydration_time"
+    dehydration_speed = "dehydration_speed"
+    error_code = "error_code"
+    rinse_count = "rinse_count"
+    rinse_level = "rinse_level"
+    wash_level = "wash_level"
+    wash_strength = "wash_strength"
+    softener = "softener"
+    detergent = "detergent"
+    
 
 class MideaDADevice(MiedaDevice):
     def __init__(
@@ -46,9 +58,21 @@ class MideaDADevice(MiedaDevice):
         self._attributes = {
             DeviceAttributes.power: False,
             DeviceAttributes.start: False,
+            DeviceAttributes.error_code: None,
             DeviceAttributes.washing_data: bytearray([]),
+            DeviceAttributes.program: None,
             DeviceAttributes.progress: "Unknown",
-            DeviceAttributes.time_remaining: None
+            DeviceAttributes.time_remaining: None,
+            DeviceAttributes.wash_time: None,
+            DeviceAttributes.soak_time: None,
+            DeviceAttributes.dehydration_time: None,
+            DeviceAttributes.dehydration_speed: None,
+            DeviceAttributes.rinse_count: None,
+            DeviceAttributes.rinse_level: None,
+            DeviceAttributes.wash_level: None,
+            DeviceAttributes.wash_strength: None,
+            DeviceAttributes.softener: None,
+            DeviceAttributes.detergent: None
         }
 
     def build_query(self):
@@ -60,10 +84,39 @@ class MideaDADevice(MiedaDevice):
         new_status = {}
         progress = ["Idle", "Spin", "Rinse", "Wash",
                     "Weight", "Unknown", "Dry", "Soak"]
+        program = ["Standard", "Fast", "Blanket", "Wool",
+                   "embathe", "Memory", "Child", "Down Jacket",
+                   "Stir", "Mute", "Bucket Self Clean", "Air Dry"]
+        speed = ["-", "Low", "Medium", "High"]
+        strength = ["-", "Week", "Medium", "Strong"]
+        detergent = ["No", "Less", "Medium", "More", "4",
+                    "5", "6", "7", "8", "Insufficient"]
+        softener = ["No", "Intelligent", "Programed", "3", "4",
+                    "5", "6", "7", "8", "Insufficient"]
         for status in self._attributes.keys():
             if hasattr(message, status.value):
                 if status == DeviceAttributes.progress:
                     self._attributes[status] = progress[getattr(message, status.value)]
+                elif status == DeviceAttributes.program:
+                    self._attributes[status] = program[getattr(message, status.value)]
+                elif status == DeviceAttributes.rinse_level:
+                    temp_rinse_level = getattr(message, status.value)
+                    if temp_rinse_level == 15:
+                        self._attributes[status] = "-"
+                    else:
+                        self._attributes[status] = temp_rinse_level
+                elif status == DeviceAttributes.dehydration_speed:
+                    temp_speed = getattr(message, status.value)
+                    if temp_speed == 15:
+                        self._attributes[status] = "-"
+                    else:
+                        self._attributes[status] = speed[temp_speed]
+                elif status == DeviceAttributes.detergent:
+                    self._attributes[status] = detergent[getattr(message, status.value)]
+                elif status == DeviceAttributes.softener:
+                    self._attributes[status] = softener[getattr(message, status.value)]
+                elif status == DeviceAttributes.wash_strength:
+                    self._attributes[status] = strength[getattr(message, status.value)]
                 else:
                     self._attributes[status] = getattr(message, status.value)
                 new_status[status.value] = self._attributes[status]
@@ -79,7 +132,6 @@ class MideaDADevice(MiedaDevice):
             message.start = value
             message.washing_data = self._attributes[DeviceAttributes.washing_data]
             self.build_send(message)
-
 
 class MideaAppliance(MideaDADevice):
     pass

--- a/custom_components/midea_ac_lan/midea/devices/da/message.py
+++ b/custom_components/midea_ac_lan/midea/devices/da/message.py
@@ -5,7 +5,6 @@ from ...core.message import (
     MessageBody,
 )
 
-
 class MessageDABase(MessageRequest):
     def __init__(self, device_protocol_version, message_type, body_type):
         super().__init__(
@@ -47,7 +46,7 @@ class MessagePower(MessageDABase):
             power, 0xFF
         ])
 
-
+        
 class MessageStart(MessageDABase):
     def __init__(self, device_protocol_version):
         super().__init__(
@@ -75,6 +74,18 @@ class DAGeneralMessageBody(MessageBody):
         super().__init__(body)
         self.power = body[1] > 0
         self.start = True if body[2] in [2, 6] else False
+        self.error_code = body[24]
+        self.program = int(hex(body[4]),16)
+        self.wash_time = body[9]
+        self.soak_time = body[12]
+        self.dehydration_time = '{:02x}'.format(body[10])[:1]
+        self.dehydration_speed = int('{:02x}'.format(body[6])[:1],16)
+        self.rinse_count = '{:02x}'.format(body[10])[1:]
+        self.rinse_level = int('{:02x}'.format(body[5])[:1],16)
+        self.wash_level = '{:02x}'.format(body[5])[1:]
+        self.wash_strength = int('{:02x}'.format(body[6])[1:],16)
+        self.softener = int('{:02x}'.format(body[8])[:1],16)
+        self.detergent = int('{:02x}'.format(body[8])[1:],16)
         self.washing_data = body[3:15]
         self.progress = 0
         for i in range(1, 7):

--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -747,11 +747,78 @@ MIDEA_DEVICES = {
                 "unit": TIME_MINUTES,
                 "state_class": SensorStateClass.MEASUREMENT
             },
+            DAAttributes.wash_time: {
+                "type": "sensor",
+                "name": "wash time",
+                "icon": "mdi:progress-clock",
+                "unit": TIME_MINUTES,
+                "state_class": SensorStateClass.MEASUREMENT
+            },
+            DAAttributes.soak_time: {
+                "type": "sensor",
+                "name": "soak time",
+                "icon": "mdi:progress-clock",
+                "unit": TIME_MINUTES,
+                "state_class": SensorStateClass.MEASUREMENT
+            },
+            DAAttributes.dehydration_time: {
+                "type": "sensor",
+                "name": "dehydration time",
+                "icon": "mdi:progress-clock",
+                "unit": TIME_MINUTES,
+                "state_class": SensorStateClass.MEASUREMENT
+            },
+            DAAttributes.dehydration_speed: {
+                "type": "sensor",
+                "name": "dehydration speed",
+                "icon": "mdi:speedometer"
+            },
+            DAAttributes.error_code: {
+                "type": "sensor",
+                "name": "error code",
+                "icon": "mdi:washing-machine-alert"
+            },
+            DAAttributes.rinse_count: {
+                "type": "sensor",
+                "name": "rinse count",
+                "icon": "mdi:water-sync"
+            },
+            DAAttributes.rinse_level: {
+                "type": "sensor",
+                "name": "rinse level",
+                "icon": "mdi:hydraulic-oil-level"
+            },
+            DAAttributes.wash_level: {
+                "type": "sensor",
+                "name": "rinse count",
+                "icon": "mdi:hydraulic-oil-level"
+            },
+            DAAttributes.wash_strength: {
+                "type": "sensor",
+                "name": "wash strength",
+                "icon": "mdi:network-strength-4-cog"
+            },
+            DAAttributes.softener: {
+                "type": "sensor",
+                "name": "softener",
+                "icon": "mdi:tshirt-crew"
+            },
+            DAAttributes.detergent: {
+                "type": "sensor",
+                "name": "detergent",
+                "icon": "mdi:spray-bottle"
+            },
+            DAAttributes.program: {
+                "type": "sensor",
+                "name": "Program",
+                "icon": "mdi:progress-wrench"
+            },
             DAAttributes.progress: {
                 "type": "sensor",
                 "name": "Progress",
                 "icon": "mdi:rotate-360"
             },
+            
             DAAttributes.power: {
                 "type": "switch",
                 "name": "Power",


### PR DESCRIPTION
base on my washer: LittleSwam TB80-6288WDCLG
added attributes: program, wash_time, soak_time, dehydration_time, dehydration_speed, error_code, rinse_count, rinse_level, wash_level, wash_strength, softener, detergent

for wash_level and rinse_level,  0=auto
for detergent, 0=no 1=less 2=mid 3=more 9=lack of detergent
for softener, 0=no 1=Intelligent 2=？？ 9=lack of softener

issues:
1. I know python less, and don't know how to split each digit from a hex num (eg. "0xab" split into a and b), so i use a stupid method to achieve...
> for example, message `body[5]` include rinse_level and wash_level,
> so i write:
>         `self.rinse_level = int('{:02x}'.format(body[5])[:1],16)`
>         `self.wash_level = '{:02x}'.format(body[5])[1:]`
> sometime rinse_level will get a "f", so i use int() to turn 

2. sometimes error_code is not the same with the machine displaying
`eg. code "F8" will become 9`
    BTW, when a error come, `body[2]=04`
3. softener will =2 when in "Mute"\"Child"\"Down Jacket"\"Stir" program, don't know the meaning, so i write "Programed"