### PR TITLE
Update midea_devices.py

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -90,6 +90,12 @@ MIDEA_DEVICES = {
                 "device_class": SensorDeviceClass.HUMIDITY,
                 "unit": PERCENTAGE,
                 "state_class": SensorStateClass.MEASUREMENT
+            },
+            A1Attributes.tank: {
+                "type": "binary_sensor",
+                "name": "Tank Status",
+                "icon": "mdi:alert-circle",
+                "device_class": BinarySensorDeviceClass.PROBLEM
             }
         }
     },


### PR DESCRIPTION
The dehumidifiers (Device A1) didn't reflect the tank status. This addition will add that status. This commit fixes issue #130 for at least my device. Hopefully for other devices as well.