### PR TITLE
Fix `int too big to convert` error after long run on protocol 3 devices

### DIFF
--- a/custom_components/midea_ac_lan/midea/core/security.py
+++ b/custom_components/midea_ac_lan/midea/core/security.py
@@ -86,10 +86,10 @@ class Security:
                 data += get_random_bytes(padding)
         header += size.to_bytes(2, "big")
         header += bytearray([0x20, padding << 4 | msgtype])
-        data = self._request_count.to_bytes(2, "big") + data
-        self._request_count += 1
         if self._request_count > 0xFFFF:
             self._request_count = 0
+        data = self._request_count.to_bytes(2, "big") + data
+        self._request_count += 1
         if msgtype in (MSGTYPE_ENCRYPTED_RESPONSE, MSGTYPE_ENCRYPTED_REQUEST):
             sign = sha256(header + data).digest()
             data = self.aes_cbc_encrypt(raw=data, key=self._tcp_key) + sign


### PR DESCRIPTION
Size check should be done before conversion.
Fix #178.
Related issues: #207, #221, #235.
Possible related issues: #225.