### PR TITLE
Update packet_builder.py

### DIFF
--- a/custom_components/midea_ac_lan/midea/core/packet_builder.py
+++ b/custom_components/midea_ac_lan/midea/core/packet_builder.py
@@ -38,7 +38,7 @@ class PacketBuilder:
             self.packet[3] = 0x10
             self.packet[6] = 0x7b
         else:
-            self.packet.extend(self.security.aes_encrypt(self.command)[:48])
+            self.packet.extend(self.security.aes_encrypt(self.command))
         # PacketLenght
         self.packet[4:6] = (len(self.packet) + 16).to_bytes(2, "little")
         # Append a basic checksum data(16 bytes) to the packet


### PR DESCRIPTION
这个地方限制了发送数据的长度，实际发送数据长度不对，按照lua文件内容，乐享3实际发送数据长度要超过48个字节