### PR TITLE
Update energy sensor state_class to total_inceasing

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -449,7 +449,7 @@ MIDEA_DEVICES = {
                 "name": "Current Energy Consumption",
                 "device_class": SensorDeviceClass.ENERGY,
                 "unit": ENERGY_KILO_WATT_HOUR,
-                "state_class": SensorStateClass.MEASUREMENT
+                "state_class": SensorStateClass.TOTAL_INCREASING
             },
             ACAttributes.realtime_power: {
                 "type": Platform.SENSOR,


### PR DESCRIPTION
There was a energy sensor with a state_class `measurement` which is incorrect. kWh entities cannot have a state_class of 'measurement'. They can only be `total` or `total_increasing`.

Fixes #372 