### PR TITLE
修复hacs下载失败

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "render_readme": true,
     "homeassistant": "2022.5",
     "zip_release": true,
-    "filename": "mieda_ac_lan.zip"
+    "filename": "midea_ac_lan.zip"
 }


### PR DESCRIPTION
hasc 下载失败 很奇怪看了下log发现
正确下载地址为  https://github.com/georgezhao2010/midea_ac_lan/releases/download/v0.3.22/midea_ac_lan.zip
hasc下载地址为  https://github.com/georgezhao2010/midea_ac_lan/releases/download/v0.3.22/mieda_ac_lan.zip
发现是配置错了